### PR TITLE
Why is FAQ sitting higher than the other options?

### DIFF
--- a/assets/section-footer.css
+++ b/assets/section-footer.css
@@ -416,7 +416,7 @@
   }
 
   .footer-block__details-content > :first-child .list-menu__item--link {
-    padding-top: 0;
+    /* padding-top: 0; */
   }
 }
 


### PR DESCRIPTION
Why do they fade in? Can they just always be there?
A lot of the pages are empty.